### PR TITLE
Check if cluster data is not null

### DIFF
--- a/infrastructure/eks_cluster/main.tf
+++ b/infrastructure/eks_cluster/main.tf
@@ -36,7 +36,8 @@ data "aws_caller_identity" "current" {}
 
 provider "kubernetes" {
   host                   = module.eks.cluster_endpoint
-  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+  
+  cluster_ca_certificate = module.eks.cluster_certificate_authority_data != null ? base64decode(module.eks.cluster_certificate_authority_data) : ""
 
   exec {
     api_version = "client.authentication.k8s.io/v1beta1"

--- a/infrastructure/eks_cluster/main.tf
+++ b/infrastructure/eks_cluster/main.tf
@@ -313,10 +313,10 @@ resource "aws_ssm_parameter" "cluster_certificate_data" {
 
 module "eks-kubeconfig" {
   source  = "hyperbadger/eks-kubeconfig/aws"
-  version = "1.0.0"
+  version = "2.0.0"
 
   depends_on = [module.eks]
-  cluster_id = module.eks.cluster_name
+  cluster_name  = module.eks.cluster_name
 }
 
 resource "local_file" "kubeconfig" {


### PR DESCRIPTION
This is to fix an error that happens when deleting a cluster'

╵
╷
│ Error: Invalid function argument
│ 
│   on .terraform/modules/eks/infrastructure/eks_cluster/main.tf line 39, in provider "kubernetes":
│   39:   cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
│     ├────────────────
│     │ while calling base64decode(str)
│     │ module.eks.cluster_certificate_authority_data is null
│ 
│ Invalid value for "str" parameter: argument must not be null.
╵

_____

Version upgrade for eks resource "hyperbadger/eks-kubeconfig/aws" from v 1.0.0 to v2.0.0