### PR TITLE
chore: attach default transport policy to s3

### DIFF
--- a/infrastructure/rds/variables.tf
+++ b/infrastructure/rds/variables.tf
@@ -233,7 +233,6 @@ variable "scheduler_timezone" {
 variable "region" {
   description = "Region to deploy the resources"
   type        = string
-  default     = "eu-west-2"
 }
 
 variable "environment" {

--- a/infrastructure/s3/main.tf
+++ b/infrastructure/s3/main.tf
@@ -1,14 +1,16 @@
 
 module "s3_bucket" {
   source = "terraform-aws-modules/s3-bucket/aws"
+  version = "4.11.0"
 
   bucket        = var.bucket_name
   acl           = var.bucket_acl
   create_bucket = var.create_bucket
 
-  control_object_ownership = var.control_object_ownership
-  object_ownership         = var.bucket_ownership
-  force_destroy            = var.force_destroy
+  control_object_ownership              = var.control_object_ownership
+  object_ownership                      = var.bucket_ownership
+  force_destroy                         = var.force_destroy
+  attach_deny_insecure_transport_policy = true
 
   versioning = {
     enabled = var.enable_versioning

--- a/kubernetes/monitoring/files/default-collector.yaml
+++ b/kubernetes/monitoring/files/default-collector.yaml
@@ -1,34 +1,39 @@
-apiVersion: opentelemetry.io/v1alpha1
+apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
 metadata:
   name: oltp-collector
   namespace: ${k8s_namespace}
 spec:
-  config: |
+  config:
     receivers:
       otlp:
         protocols:
           grpc:
+            endpoint: 0.0.0.0:4317
           http:
-    processors:
-      memory_limiter:
-        check_interval: 1s
-        limit_percentage: 75
-        spike_limit_percentage: 15
-      batch:
-        send_batch_size: 10000
-        timeout: 10s
-
+            endpoint: 0.0.0.0:4318
     exporters:
-      debug:
+      debug: null
       otlp:
         endpoint: ${collector_exporter_endpoint}:4317
         tls:
           insecure: true
-
+    processors:
+      batch:
+        send_batch_size: 10000
+        timeout: 10s
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 75
+        spike_limit_percentage: 15
     service:
       pipelines:
         traces:
-          receivers: [otlp]
-          processors: [memory_limiter, batch]
-          exporters: [debug, otlp]
+          exporters:
+            - debug
+            - otlp
+          processors:
+            - memory_limiter
+            - batch
+          receivers:
+            - otlp


### PR DESCRIPTION
### **User description**
**S3 Infrastructure Improvements:**

* Pinned the S3 bucket Terraform module to version `4.11.0` in `main.tf` for improved stability and reproducibility.
* Enabled the `attach_deny_insecure_transport_policy` option in the S3 bucket module to enforce secure transport and enhance bucket security.

**General Infrastructure Change:**

* Removed the default value for the `region` variable in `variables.tf`, requiring explicit region specification and reducing the risk of accidental deployments to the wrong region.


___

### **PR Type**
Enhancement, Other


___

### **Description**
- Pinned S3 bucket Terraform module to version 4.11.0 for stability

- Enabled deny insecure transport policy on S3 bucket for security

- Removed default region value from RDS variables for explicit specification

- Updated OpenTelemetry Collector to v1beta1 API with improved configuration structure


___

### Diagram Walkthrough


```mermaid
flowchart LR
  S3["S3 Module"] -- "pin version 4.11.0" --> S3V["Versioned Module"]
  S3V -- "attach_deny_insecure_transport_policy" --> S3SEC["Secure Transport"]
  RDS["RDS Variables"] -- "remove default region" --> RDSEXplicit["Explicit Region Required"]
  OT["OpenTelemetry Collector"] -- "upgrade to v1beta1" --> OTAPI["Updated API"]
  OTAPI -- "restructure config" --> OTConfig["Improved Configuration"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>S3 module versioning and security policy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/s3/main.tf

<ul><li>Pinned S3 bucket module to version 4.11.0<br> <li> Added <code>attach_deny_insecure_transport_policy = true</code> to enforce secure <br>transport<br> <li> Reformatted variable alignment for improved readability</ul>


</details>


  </td>
  <td><a href="https://github.com/FITER1/fiter-enterprise-tf-modules/pull/20/files#diff-f2a13c6cf06c699f565ad7cd9655a609c9a4b292fd6680dcfc4b146c0d7944fb">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>default-collector.yaml</strong><dd><code>OpenTelemetry Collector API upgrade and config restructuring</code></dd></summary>
<hr>

kubernetes/monitoring/files/default-collector.yaml

<ul><li>Upgraded OpenTelemetry Collector API from v1alpha1 to v1beta1<br> <li> Added explicit gRPC and HTTP endpoints (0.0.0.0:4317 and 0.0.0.0:4318)<br> <li> Restructured configuration with improved YAML formatting and <br>organization<br> <li> Changed debug exporter to null and reorganized processors and <br>exporters sections</ul>


</details>


  </td>
  <td><a href="https://github.com/FITER1/fiter-enterprise-tf-modules/pull/20/files#diff-43769fd15265da4962322d0f58b8f40438bd8f12d2685ea0d07408f912ce5b48">+21/-16</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Remove default region variable value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/rds/variables.tf

<ul><li>Removed default value "eu-west-2" from <code>region</code> variable<br> <li> Requires explicit region specification for deployments</ul>


</details>


  </td>
  <td><a href="https://github.com/FITER1/fiter-enterprise-tf-modules/pull/20/files#diff-d35c2f8476a2189c0b15aad4d8b8567390f8ec9bea0d6d4958c0c7e15dbec83c">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

