### PR TITLE
feat: enable inline policy for Karpenter module

### DIFF
--- a/infrastructure/eks_cluster/main.tf
+++ b/infrastructure/eks_cluster/main.tf
@@ -273,6 +273,7 @@ module "karpenter" {
   create_instance_profile         = false
   create_access_entry             = true
   namespace                       = var.karpenter_namespace
+  enable_inline_policy            = true
   service_account                 = var.karpenter_service_account
   node_iam_role_additional_policies = merge({
     AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"


### PR DESCRIPTION
* Enabled the `enable_inline_policy` flag in the `karpenter` module configuration within `main.tf`, allowing the attachment of inline policies to the Karpenter service account.