### PR TITLE
feat(rds-credential-manager): bundle lambda source and overrides

### DIFF
--- a/infrastructure/rds-credential-manager/README.md
+++ b/infrastructure/rds-credential-manager/README.md
@@ -142,7 +142,7 @@ module "credential_manager" {
 | <a name="input_function_code_path"></a> [function\_code\_path](#input\_function\_code\_path) | Path to the Lambda function code | `string` | `"lambdas"` | no |
 | <a name="input_function_source"></a> [function\_source](#input\_function\_source) | The source type for the Lambda function (zip or image) | `string` | n/a | yes |
 | <a name="input_lambda_environment_variables"></a> [lambda\_environment\_variables](#input\_lambda\_environment\_variables) | Extra environment variables merged into the Lambda's environment block. Override module-defaults by setting the same key here. | `map(string)` | `{}` | no |
-| <a name="input_lambda_source_path"></a> [lambda\_source\_path](#input\_lambda\_source\_path) | Optional override for the Lambda source directory. When empty, the module's bundled lambdas/${var.engine}/ is used. Set to an absolute or path.root-relative path to point at consumer-supplied source. | `string` | `""` | no |
+| <a name="input_lambda_source_path"></a> [lambda\_source\_path](#input\_lambda\_source\_path) | Optional override for the Lambda source directory, resolved relative to the consumer workspace root (path.root). When empty, the module's bundled lambdas/${var.engine}/ is used. Example: "lambdas/mysql" points at <workspace>/lambdas/mysql. | `string` | `""` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the resource | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | AWS region | `string` | n/a | yes |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | List of security group IDs to associate with the RDS cluster | `list(string)` | n/a | yes |

--- a/infrastructure/rds-credential-manager/README.md
+++ b/infrastructure/rds-credential-manager/README.md
@@ -141,6 +141,8 @@ module "credential_manager" {
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name | `string` | n/a | yes |
 | <a name="input_function_code_path"></a> [function\_code\_path](#input\_function\_code\_path) | Path to the Lambda function code | `string` | `"lambdas"` | no |
 | <a name="input_function_source"></a> [function\_source](#input\_function\_source) | The source type for the Lambda function (zip or image) | `string` | n/a | yes |
+| <a name="input_lambda_environment_variables"></a> [lambda\_environment\_variables](#input\_lambda\_environment\_variables) | Extra environment variables merged into the Lambda's environment block. Override module-defaults by setting the same key here. | `map(string)` | `{}` | no |
+| <a name="input_lambda_source_path"></a> [lambda\_source\_path](#input\_lambda\_source\_path) | Optional override for the Lambda source directory. When empty, the module's bundled lambdas/${var.engine}/ is used. Set to an absolute or path.root-relative path to point at consumer-supplied source. | `string` | `""` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the resource | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | AWS region | `string` | n/a | yes |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | List of security group IDs to associate with the RDS cluster | `list(string)` | n/a | yes |

--- a/infrastructure/rds-credential-manager/lambdas/mysql/index.py
+++ b/infrastructure/rds-credential-manager/lambdas/mysql/index.py
@@ -1,0 +1,180 @@
+import os
+import json
+import logging
+import pymysql.cursors
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def create_secret(client, secret_name, username):
+    try:
+        randomPassword = client.get_random_password(
+            PasswordLength=16,
+            ExcludePunctuation=True
+        )
+        password = randomPassword["RandomPassword"]
+        secret = json.dumps({
+            "username": username,
+            "password": password
+        })
+        client.create_secret(
+            Name=secret_name,
+            SecretString=secret,
+            Tags=[
+                {
+                    'Key': 'OwnedBy',
+                    'Value': 'Terraform'
+                }
+            ],
+        )
+    except ClientError as error:
+        if error.response['Error']['Code'] == 'ResourceExistsException':
+            secret = get_secret(client, secret_name)
+            password = secret["password"]
+        else:
+            raise error
+
+    return password
+
+def get_secret(client, secret_name):
+    logger.info(f"attempting to get {secret_name}")
+    try:
+        get_secret_value_response = client.get_secret_value(
+            SecretId=secret_name
+        )
+    except ClientError as e:
+        raise e
+    
+    secret = get_secret_value_response['SecretString']
+    return json.loads(secret)
+
+def delete_secret(client, secret_name):
+    logger.info(f"attempting to Delete {secret_name}")
+    try:
+        response = client.delete_secret(
+            SecretId=secret_name,
+            ForceDeleteWithoutRecovery=True
+        )
+    except ClientError as e:
+        raise e
+    return True
+
+
+
+queries = {
+    "CREATE_DB": "CREATE DATABASE IF NOT EXISTS %s;",
+    "CREATE_USER": "CREATE USER %s@'%%' IDENTIFIED BY %s;",
+    "GRANT_SERVICE": "GRANT ALL PRIVILEGES ON %s.* TO %s@'%%';",
+    "FLUSH": "FLUSH PRIVILEGES;",
+    "DROP_USER": "DROP USER IF EXISTS %s;",
+    "USER_EXIST": "SELECT user FROM mysql.user WHERE user = %s;",
+    "DB_EXIST": "SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = %s;"
+}
+
+def createConnection(db_secret, host, db_name, db_port=3306):
+    conn = pymysql.connect(host=host,
+                                user=db_secret["username"],
+                                password=db_secret["password"],
+                                database=db_name,
+                                charset='utf8mb4',
+                                port=db_port,
+                                cursorclass=pymysql.cursors.DictCursor)
+    return conn
+
+def lambda_handler(event, context):
+    SECRET_PATH = os.environ["SECRET_PATH"]
+    USER_NAME = f'{event["USERNAME"]}'
+    SECRET_NAME = f'{SECRET_PATH}/{USER_NAME}'
+    DATABASES = event["DATABASES"]
+    REGION_NAME = os.environ['AWS_REGION']
+    ADMIN_SECRET_NAME = os.environ["ADMIN_SECRET_NAME"]
+    DB_HOST = os.environ["DB_HOST"]
+    DB_PORT = int(os.environ.get("DB_PORT", 3306))
+    ADMIN_DB_NAME = os.environ["ADMIN_DB_NAME"]
+    DB_INIT = f'{event["DB_INIT"]}'
+    ACCESS_TYPE = f'{event["ACCESS_TYPE"]}'
+
+    session = boto3.session.Session()
+    client = session.client(
+        service_name='secretsmanager',
+        region_name=REGION_NAME
+    )
+
+    db_secret = get_secret(client, ADMIN_SECRET_NAME)
+    
+    # Initialize cursor and conn to None
+    cursor = None
+    conn = None
+    
+    try:
+        conn = createConnection(db_secret, DB_HOST, ADMIN_DB_NAME, DB_PORT)
+        admin_user = db_secret["username"]
+        cursor = conn.cursor()
+        
+        if DB_INIT == "True":
+            cursor.execute(f"GRANT ROLE_ADMIN on *.* TO {admin_user};")
+        else:
+            ACTION = event["tf"]["action"]
+            if ACTION == "create":
+                for database_name in DATABASES:
+                    cursor.execute(queries["DB_EXIST"], (database_name,))
+                    exists = cursor.fetchone()
+                    if not exists:
+                        cursor.execute(f"CREATE DATABASE IF NOT EXISTS {database_name};")
+
+
+                cursor.execute(queries["USER_EXIST"], (USER_NAME,))
+                user_exists = cursor.fetchone() is not None
+
+                if user_exists:
+                    logger.info(f"User '{USER_NAME}' already exists.")
+                else:
+                    user_secret = create_secret(client, SECRET_NAME, USER_NAME)
+
+                    CREATE_USER_SQL = queries["CREATE_USER"]
+                    cursor.execute(CREATE_USER_SQL, (USER_NAME, user_secret))
+                    for database_name in DATABASES:
+                        if ACCESS_TYPE == 'readwrite':
+                            cursor.execute(f"GRANT ALL ON {database_name}.* TO %s@'%%';", (USER_NAME,))
+                        else:
+                            cursor.execute(f"GRANT SELECT ON {database_name}.* TO %s@'%%';", (USER_NAME,))
+                        logger.info(f"User {USER_NAME} created successfully with Role {ACCESS_TYPE} on database {database_name}.")
+                    logger.info(f"User '{USER_NAME}' created.")
+                # Commit the changes
+                conn.commit()
+                cursor.execute(queries["FLUSH"])
+
+            elif ACTION == "update":
+                # Grant all permissions on the database to the user
+                for database_name in DATABASES:
+                    if ACCESS_TYPE == 'readwrite':
+                        cursor.execute(f"GRANT ALL ON {database_name}.* TO %s@'%%';", (USER_NAME,))
+                    else:
+                        cursor.execute(f"GRANT SELECT ON {database_name}.* TO %s@'%%';", (USER_NAME,))
+                    logger.info(f"User {USER_NAME} update successfully with Role {ACCESS_TYPE} on database {database_name}.")
+                conn.commit()
+                cursor.execute(queries["FLUSH"])
+            elif ACTION == "delete":
+                delete_secret(client, SECRET_NAME)
+                # Delete User
+                DROP_USER_SQL = queries["DROP_USER"]
+                cursor.execute(DROP_USER_SQL, (USER_NAME))
+                conn.commit()
+                cursor.execute(queries["FLUSH"])
+            else:
+                logger.info(f"No Action to take'")
+
+    except pymysql.MySQLError as e:
+        logger.error(f"Error: {e}")
+    finally:
+        if cursor is not None:
+            cursor.close()
+        if conn is not None:
+            conn.close()
+        
+    return {
+        "secretname": SECRET_NAME
+    }

--- a/infrastructure/rds-credential-manager/lambdas/postgres/Dockerfile
+++ b/infrastructure/rds-credential-manager/lambdas/postgres/Dockerfile
@@ -1,0 +1,6 @@
+FROM amazon/aws-lambda-python:3.9-x86_64
+COPY requirements.txt .
+RUN pip3 install -r requirements.txt
+COPY app.py ./
+
+CMD ["app.lambda_handler"]

--- a/infrastructure/rds-credential-manager/lambdas/postgres/index.py
+++ b/infrastructure/rds-credential-manager/lambdas/postgres/index.py
@@ -1,0 +1,218 @@
+import os
+import json
+import logging
+import boto3
+from botocore.exceptions import ClientError
+import psycopg2
+from psycopg2 import sql
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+def create_secret(client, secret_name, username):
+    try:
+        randomPassword = client.get_random_password(
+            PasswordLength=16,
+            ExcludePunctuation=True
+        )
+        password = randomPassword["RandomPassword"]
+        secret = json.dumps({
+            "username": username,
+            "password": password
+        })
+        client.create_secret(
+            Name=secret_name,
+            SecretString=secret,
+            Tags=[
+                {
+                    'Key': 'OwnedBy',
+                    'Value': 'Terraform'
+                },
+            ],
+        )
+    except ClientError as error:
+        if error.response['Error']['Code'] == 'ResourceExistsException':
+            secret = get_secret(client, secret_name)
+            password = secret["password"]
+        else:
+            raise error
+
+    return password
+
+def get_secret(client, secret_name):
+    logger.info(f"attempting to get {secret_name}")
+    try:
+        get_secret_value_response = client.get_secret_value(
+            SecretId=secret_name
+        )
+    except ClientError as e:
+        raise e
+    
+    secret = get_secret_value_response['SecretString']
+    return json.loads(secret)
+
+def delete_secret(client, secret_name):
+    logger.info(f"attempting to Delete {secret_name}")
+    try:
+        response = client.delete_secret(
+            SecretId=secret_name,
+            ForceDeleteWithoutRecovery=True
+        )
+    except ClientError as e:
+        raise e
+    return True
+
+def db_connection_manager(db_params, database, query):
+    db_params["database"] = database
+    try:
+        connection = psycopg2.connect(**db_params)
+        connection.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+        connection.autocommit = True
+        cursor = connection.cursor()
+        cursor.execute(query)
+    except (Exception, psycopg2.Error) as error:
+        logger.error(f"Error connecting to the database: {error}")
+    finally:
+        if connection:
+            cursor.close()
+            connection.close()
+            logger.info("Database connection closed.")
+    return True
+
+def db_manager(event):
+    DB_IDENTIFIER = os.environ["DB_IDENTIFIER"]
+    USER_NAME = f'{event["USERNAME"]}'
+    SECRET_NAME = f'{DB_IDENTIFIER}-{USER_NAME}-secret'
+    DATABASES = event["DATABASES"]
+    REGION_NAME = os.environ['AWS_REGION']
+    ADMIN_SECRET_NAME = os.environ["ADMIN_SECRET_NAME"]
+    DB_HOST = os.environ["DB_HOST"]
+    ADMIN_DB_NAME = os.environ["ADMIN_DB_NAME"]
+    DB_INIT = f'{event["DB_INIT"]}'
+    ACCESS_TYPE = f'{event["ACCESS_TYPE"]}'
+
+    session = boto3.session.Session()
+    client = session.client(
+        service_name='secretsmanager',
+        region_name=REGION_NAME
+    )
+
+    db_secret = get_secret(client, ADMIN_SECRET_NAME)
+
+    db_params = {
+        "host": DB_HOST,
+        "database": ADMIN_DB_NAME,
+        "user": db_secret["username"],
+        "password": db_secret["password"],
+        "port": "5432",
+        "sslmode": "require"
+    }
+
+    try:
+        connection = psycopg2.connect(**db_params)
+        connection.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+        connection.autocommit = True
+        cursor = connection.cursor()
+
+        if DB_INIT == "True":
+            cursor.execute("REVOKE CREATE ON SCHEMA public FROM PUBLIC;")
+        else:
+            ACTION = event["tf"]["action"]
+            if ACTION == "create":
+                for database_name in DATABASES:
+                    cursor.execute("SELECT 1 FROM pg_catalog.pg_database WHERE datname = %s", (database_name,))
+                    exists = cursor.fetchone()
+                    if not exists:
+                        cursor.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(database_name)))
+                        cursor.execute(f"REVOKE ALL ON DATABASE {database_name} FROM PUBLIC")
+                        cursor.execute(f"CREATE ROLE {database_name}_readwrite")
+                        cursor.execute(f"GRANT CONNECT ON DATABASE {database_name} TO {database_name}_readwrite")
+                        cursor.execute(f"CREATE ROLE {database_name}_readonly")
+                        cursor.execute(f"GRANT CONNECT ON DATABASE {database_name} TO {database_name}_readonly")
+
+                        queries = f"""
+                            DO $$
+                            BEGIN
+                                REVOKE CREATE ON SCHEMA public FROM PUBLIC;
+                                GRANT USAGE, CREATE ON SCHEMA public TO {database_name}_readwrite;
+                                GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO {database_name}_readwrite;
+                                ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO {database_name}_readwrite;
+                                GRANT USAGE ON ALL SEQUENCES IN SCHEMA public TO {database_name}_readwrite;
+                                GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO {database_name}_readwrite;
+                                ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE ON SEQUENCES TO {database_name}_readwrite;
+                                GRANT pg_write_all_data TO {database_name}_readwrite;
+                                GRANT USAGE ON SCHEMA public TO {database_name}_readonly;
+                                GRANT SELECT ON ALL TABLES IN SCHEMA public TO {database_name}_readonly;
+                                ALTER DEFAULT PRIVILEGES FOR ROLE {database_name}_readwrite IN SCHEMA public GRANT SELECT ON TABLES TO {database_name}_readonly;
+                                ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO {database_name}_readonly;
+                                GRANT pg_read_all_data TO {database_name}_readonly;
+                            END $$;
+                        """
+                        db_connection_manager(db_params, database_name, queries)
+                        logger.info(f"Database {database_name} created successfully.")
+                    else:
+                        logger.info(f"Database {database_name} already exists.")
+
+                cursor.execute("SELECT 1 FROM pg_roles WHERE rolname=%s", (USER_NAME,))
+                user_exists = cursor.fetchone()
+
+                if not user_exists:
+                    user_secret = create_secret(client, SECRET_NAME, USER_NAME)
+                    cursor.execute(
+                        sql.SQL("CREATE USER {} WITH PASSWORD %s").format(
+                            sql.Identifier(USER_NAME)
+                        ),
+                        (user_secret,)
+                    )
+                    cursor.execute(f"REVOKE ALL PRIVILEGES ON DATABASE postgres FROM {USER_NAME}")
+                    for database_name in DATABASES:
+                        queries = f"GRANT {database_name}_{ACCESS_TYPE} TO {USER_NAME}"
+                        db_connection_manager(db_params, database_name, queries)
+                        logger.info(f"User {USER_NAME} created successfully with Role {database_name}_{ACCESS_TYPE}.")
+                else:
+                    logger.info(f"User {USER_NAME} already exists.")
+            elif ACTION == "update":
+                for database_name in DATABASES:
+                    queries = f"GRANT {database_name}_{ACCESS_TYPE} TO {USER_NAME}"
+                    db_connection_manager(db_params, database_name, queries)
+                    logger.info(f"User {USER_NAME} updated successfully with Role {database_name}_{ACCESS_TYPE}.")
+
+            elif ACTION == "delete":
+                for database_name in DATABASES:
+                    queries = f"REVOKE {database_name}_{ACCESS_TYPE} FROM {USER_NAME}"
+                    db_connection_manager(db_params, database_name, queries)
+                
+                cursor.execute(f"DROP USER IF EXISTS {USER_NAME}")
+                delete_secret(client, SECRET_NAME)
+            else:
+                logger.info(f"No Action to take'")
+
+    except (Exception, psycopg2.Error) as error:
+        logger.info(f"Error connecting to the database: {error}")
+
+    finally:
+        if connection:
+            cursor.close()
+            connection.close()
+            logger.info("Database connection closed.")
+            
+    return {
+        "secretname": SECRET_NAME
+    }
+
+def lambda_handler(event, context):
+    try:
+        db_manager(event)
+    except Exception as e:
+        logger.error(f"Error in lambda_handler: {e}")
+
+if __name__ == "__main__":
+    if os.environ.get("LAMBDA_TASK_ROOT") == None:
+        config_file = os.environ.get("CONFIG_FILE")
+        if not config_file:
+            raise ValueError("CONFIG_FILE environment variable must be set when running locally")
+
+        with open(config_file, "r") as file:
+            event_data = json.load(file)
+            db_manager(event_data)

--- a/infrastructure/rds-credential-manager/lambdas/postgres/requirements.txt
+++ b/infrastructure/rds-credential-manager/lambdas/postgres/requirements.txt
@@ -1,0 +1,4 @@
+psycopg==3.2.6
+psycopg-binary==3.2.6
+psycopg-pool==3.2.6
+libq==0.5.0

--- a/infrastructure/rds-credential-manager/locals.tf
+++ b/infrastructure/rds-credential-manager/locals.tf
@@ -19,7 +19,7 @@ locals {
       package_type = "Zip"
       handler      = "index.lambda_handler"
       runtime      = "python3.9"
-      source_path  = "${path.root}/lambdas/${var.engine}"
+      source_path  = var.lambda_source_path != "" ? var.lambda_source_path : "${path.module}/lambdas/${var.engine}"
       layers       = [module.pymysql_layer.lambda_layer_arn]
     }
     image = {

--- a/infrastructure/rds-credential-manager/locals.tf
+++ b/infrastructure/rds-credential-manager/locals.tf
@@ -19,7 +19,7 @@ locals {
       package_type = "Zip"
       handler      = "index.lambda_handler"
       runtime      = "python3.9"
-      source_path  = var.lambda_source_path != "" ? var.lambda_source_path : "${path.module}/lambdas/${var.engine}"
+      source_path  = var.lambda_source_path != "" ? "${path.root}/${var.lambda_source_path}" : "${path.module}/lambdas/${var.engine}"
       layers       = [module.pymysql_layer.lambda_layer_arn]
     }
     image = {

--- a/infrastructure/rds-credential-manager/main.tf
+++ b/infrastructure/rds-credential-manager/main.tf
@@ -29,14 +29,17 @@ module "credential_manager" {
   attach_network_policy  = true
   timeout                = var.timeout
 
-  environment_variables = {
-    ADMIN_SECRET_NAME = var.admin_secret_arn
-    DB_HOST           = var.database_host
-    ADMIN_DB_NAME     = var.database_admin_db
-    DB_IDENTIFIER     = var.database_identifier
-    DB_PORT           = var.database_port
-    SECRET_PATH       = local.secret_path
-  }
+  environment_variables = merge(
+    {
+      ADMIN_SECRET_NAME = var.admin_secret_arn
+      DB_HOST           = var.database_host
+      ADMIN_DB_NAME     = var.database_admin_db
+      DB_IDENTIFIER     = var.database_identifier
+      DB_PORT           = var.database_port
+      SECRET_PATH       = local.secret_path
+    },
+    var.lambda_environment_variables
+  )
 
   attach_policy_json = true
   policy_json        = data.aws_iam_policy_document.credential_manager_lambda.json

--- a/infrastructure/rds-credential-manager/variable.tf
+++ b/infrastructure/rds-credential-manager/variable.tf
@@ -126,6 +126,18 @@ variable "function_code_path" {
   default     = "lambdas"
 }
 
+variable "lambda_environment_variables" {
+  type        = map(string)
+  description = "Extra environment variables merged into the Lambda's environment block. Override module-defaults by setting the same key here."
+  default     = {}
+}
+
+variable "lambda_source_path" {
+  type        = string
+  description = "Optional override for the Lambda source directory. When empty, the module's bundled lambdas/$${var.engine}/ is used. Set to an absolute or path.root-relative path to point at consumer-supplied source."
+  default     = ""
+}
+
 variable "enable_secretmanager_vpc_endpoint" {
   type        = bool
   description = "Enable VPC Endpoint for Secrets Manager"

--- a/infrastructure/rds-credential-manager/variable.tf
+++ b/infrastructure/rds-credential-manager/variable.tf
@@ -134,7 +134,7 @@ variable "lambda_environment_variables" {
 
 variable "lambda_source_path" {
   type        = string
-  description = "Optional override for the Lambda source directory. When empty, the module's bundled lambdas/$${var.engine}/ is used. Set to an absolute or path.root-relative path to point at consumer-supplied source."
+  description = "Optional override for the Lambda source directory, resolved relative to the consumer workspace root (path.root). When empty, the module's bundled lambdas/$${var.engine}/ is used. Example: \"lambdas/mysql\" points at <workspace>/lambdas/mysql."
   default     = ""
 }
 


### PR DESCRIPTION
## Summary
- Bundle lambda source (`mysql/`, `postgres/`) inside the module so consumers no longer need `lambdas/<engine>/` at `path.root`.
- Two new optional vars: `lambda_source_path` (override bundled source) and `lambda_environment_variables` (merged into the lambda env block; consumer keys win on conflict).
- Fixes downstream scaffolder break: `FITER1/fiter-infrastructure-v2-template` removed its template-side `lambdas/` tree, so new MySQL onboardings were failing at apply with `source_path not found`.

Default behaviour for existing consumers is preserved — `source_path` falls back to `${path.module}/lambdas/${var.engine}`. No consumer action needed unless they want custom source or extra env vars.

## Test plan
- [x] `terraform fmt -check -recursive` at repo root
- [x] `terraform init -backend=false && terraform validate` in `infrastructure/rds-credential-manager/example`
- [x] Verified only the four intended files copied (no venv / `bin/` / `.DS_Store` leaked from the source tree)
- [ ] CI `Validate: infrastructure/rds-credential-manager` passes
- [ ] CI `docs` job regenerates the module README to surface the two new vars

## Follow-up (post-merge)
- Cut `v0.3.0` (release-drafter will pick `feat` → minor)
- Bump `.module-version` in `FITER1/fiter-infrastructure-v2-template`