### PR TITLE
feat(s3)!: bundle optional IAM writer + Secrets Manager; fix s3_bucket_id output

### DIFF
--- a/infrastructure/s3/README.md
+++ b/infrastructure/s3/README.md
@@ -1,5 +1,5 @@
 <!-- BEGIN_TF_DOCS -->
-
+Creates an S3 bucket and, when enable\_iam\_writer is true, also creates a dedicated IAM writer user with generated access keys stored in AWS Secrets Manager for object read/write workflows.
 
 ## Requirements
 
@@ -10,7 +10,9 @@
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
 
 ## Usage
 To use this module in your Terraform environment, include it in your Terraform configuration with the necessary parameters. Below is an example of how to use this module:
@@ -34,35 +36,75 @@ module "app_assets" {
   # enable_versioning = true           # default; set to false if versioning is not needed
   # force_destroy     = true           # default; set to false to prevent accidental deletion in production
 }
+
+module "app_assets_with_writer" {
+  source = "../"
+
+  bucket_name       = "example-customer-dev-app-assets-writer"
+  create_bucket     = true
+  enable_iam_writer = true
+  iam_user_tags = {
+    Purpose = "upload"
+  }
+
+  tags = {
+    Name        = "example-customer-dev-app-assets-writer"
+    Environment = "dev"
+    ManagedBy   = "terraform"
+  }
+}
 ```
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 5.0 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 5.13 |
+| <a name="module_writer"></a> [writer](#module\_writer) | terraform-aws-modules/iam/aws//modules/iam-user | ~> 6.6 |
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_iam_policy.writer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_secretsmanager_secret.writer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.writer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_block_public_acls"></a> [block\_public\_acls](#input\_block\_public\_acls) | Whether Amazon S3 should block public ACLs for this bucket. | `bool` | `null` | no |
+| <a name="input_block_public_policy"></a> [block\_public\_policy](#input\_block\_public\_policy) | Whether Amazon S3 should block public bucket policies for this bucket. | `bool` | `null` | no |
 | <a name="input_bucket_acl"></a> [bucket\_acl](#input\_bucket\_acl) | The canned ACL to apply to the S3 bucket | `string` | `"private"` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The name of the S3 bucket | `string` | n/a | yes |
 | <a name="input_bucket_ownership"></a> [bucket\_ownership](#input\_bucket\_ownership) | Whether to control ownership of objects in the bucket | `string` | `"ObjectWriter"` | no |
 | <a name="input_control_object_ownership"></a> [control\_object\_ownership](#input\_control\_object\_ownership) | value to control object ownership | `bool` | `true` | no |
 | <a name="input_create_bucket"></a> [create\_bucket](#input\_create\_bucket) | Whether to create the S3 bucket | `bool` | `false` | no |
+| <a name="input_enable_iam_writer"></a> [enable\_iam\_writer](#input\_enable\_iam\_writer) | Create a dedicated IAM user with object R/W permissions on this bucket; store generated access keys in Secrets Manager. | `bool` | `false` | no |
 | <a name="input_enable_versioning"></a> [enable\_versioning](#input\_enable\_versioning) | Whether to enable bucket versioning | `bool` | `true` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error | `bool` | `true` | no |
+| <a name="input_iam_policy_name_override"></a> [iam\_policy\_name\_override](#input\_iam\_policy\_name\_override) | Override derived IAM policy name. Renaming an existing policy forces replace. | `string` | `""` | no |
+| <a name="input_iam_user_name_override"></a> [iam\_user\_name\_override](#input\_iam\_user\_name\_override) | Override derived IAM user name. IAM user names are unique account-wide. | `string` | `""` | no |
+| <a name="input_iam_user_tags"></a> [iam\_user\_tags](#input\_iam\_user\_tags) | Tags merged on top of var.tags for the IAM user only. | `map(string)` | `{}` | no |
+| <a name="input_ignore_public_acls"></a> [ignore\_public\_acls](#input\_ignore\_public\_acls) | Whether Amazon S3 should ignore public ACLs for this bucket. | `bool` | `null` | no |
+| <a name="input_restrict_public_buckets"></a> [restrict\_public\_buckets](#input\_restrict\_public\_buckets) | Whether Amazon S3 should restrict public bucket policies for this bucket. | `bool` | `null` | no |
+| <a name="input_secret_kms_key_id"></a> [secret\_kms\_key\_id](#input\_secret\_kms\_key\_id) | Optional KMS CMK ARN/ID for the Secrets Manager secret. Defaults to AWS-managed aws/secretsmanager. | `string` | `null` | no |
+| <a name="input_secret_name_override"></a> [secret\_name\_override](#input\_secret\_name\_override) | Override derived Secrets Manager secret name. | `string` | `""` | no |
+| <a name="input_secret_recovery_window_in_days"></a> [secret\_recovery\_window\_in\_days](#input\_secret\_recovery\_window\_in\_days) | Recovery window for the Secrets Manager secret. Set to 0 in dev/test to allow immediate destroy+recreate. | `number` | `7` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to apply to the S3 bucket | `map(string)` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | n/a |
-| <a name="output_s3_bucket_id"></a> [s3\_bucket\_id](#output\_s3\_bucket\_id) | n/a |
+| <a name="output_iam_writer_access_key_id"></a> [iam\_writer\_access\_key\_id](#output\_iam\_writer\_access\_key\_id) | The IAM writer access key ID, when enabled. |
+| <a name="output_iam_writer_secret_arn"></a> [iam\_writer\_secret\_arn](#output\_iam\_writer\_secret\_arn) | The Secrets Manager secret ARN containing the IAM writer credentials, when enabled. |
+| <a name="output_iam_writer_secret_name"></a> [iam\_writer\_secret\_name](#output\_iam\_writer\_secret\_name) | The Secrets Manager secret name containing the IAM writer credentials, when enabled. |
+| <a name="output_iam_writer_user_arn"></a> [iam\_writer\_user\_arn](#output\_iam\_writer\_user\_arn) | The IAM writer user ARN, when enabled. |
+| <a name="output_iam_writer_user_name"></a> [iam\_writer\_user\_name](#output\_iam\_writer\_user\_name) | The IAM writer user name, when enabled. |
+| <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | The ARN of the S3 bucket. |
+| <a name="output_s3_bucket_domain_name"></a> [s3\_bucket\_domain\_name](#output\_s3\_bucket\_domain\_name) | The bucket domain name. |
+| <a name="output_s3_bucket_id"></a> [s3\_bucket\_id](#output\_s3\_bucket\_id) | The name/id of the S3 bucket. |
 <!-- END_TF_DOCS -->

--- a/infrastructure/s3/example/main.tf
+++ b/infrastructure/s3/example/main.tf
@@ -16,3 +16,20 @@ module "app_assets" {
   # enable_versioning = true           # default; set to false if versioning is not needed
   # force_destroy     = true           # default; set to false to prevent accidental deletion in production
 }
+
+module "app_assets_with_writer" {
+  source = "../"
+
+  bucket_name       = "example-customer-dev-app-assets-writer"
+  create_bucket     = true
+  enable_iam_writer = true
+  iam_user_tags = {
+    Purpose = "upload"
+  }
+
+  tags = {
+    Name        = "example-customer-dev-app-assets-writer"
+    Environment = "dev"
+    ManagedBy   = "terraform"
+  }
+}

--- a/infrastructure/s3/locals.tf
+++ b/infrastructure/s3/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  iam_user_name   = var.iam_user_name_override != "" ? var.iam_user_name_override : "${var.bucket_name}-writer"
+  iam_policy_name = var.iam_policy_name_override != "" ? var.iam_policy_name_override : "${local.iam_user_name}-policy"
+  secret_name     = var.secret_name_override != "" ? var.secret_name_override : "s3/${var.bucket_name}/writer"
+  bucket_arn      = var.create_bucket ? module.s3_bucket.s3_bucket_arn : "arn:${data.aws_partition.current.partition}:s3:::${var.bucket_name}"
+}

--- a/infrastructure/s3/main.tf
+++ b/infrastructure/s3/main.tf
@@ -1,14 +1,23 @@
+/**
+ * Creates an S3 bucket and, when enable_iam_writer is true, also creates a dedicated IAM writer user with generated access keys stored in AWS Secrets Manager for object read/write workflows.
+ */
+
+data "aws_partition" "current" {}
 
 module "s3_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "~> 5.0"
+  version = "~> 5.13"
 
   bucket        = var.bucket_name
   acl           = var.bucket_acl
   create_bucket = var.create_bucket
 
+  block_public_acls                     = var.block_public_acls
+  block_public_policy                   = var.block_public_policy
   control_object_ownership              = var.control_object_ownership
+  ignore_public_acls                    = var.ignore_public_acls
   object_ownership                      = var.bucket_ownership
+  restrict_public_buckets               = var.restrict_public_buckets
   force_destroy                         = var.force_destroy
   attach_deny_insecure_transport_policy = true
 
@@ -17,4 +26,53 @@ module "s3_bucket" {
   }
 
   tags = var.tags
+}
+
+resource "aws_iam_policy" "writer" {
+  count       = var.enable_iam_writer ? 1 : 0
+  name        = local.iam_policy_name
+  path        = "/"
+  description = "R/W access to s3://${var.bucket_name}"
+  tags        = var.tags
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["s3:PutObject", "s3:GetObject", "s3:ListBucket", "s3:DeleteObject"]
+      Resource = [local.bucket_arn, "${local.bucket_arn}/*"]
+    }]
+  })
+}
+
+module "writer" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-user"
+  version = "~> 6.6"
+  count   = var.enable_iam_writer ? 1 : 0
+
+  create               = true
+  name                 = local.iam_user_name
+  create_login_profile = false
+  create_access_key    = true
+  policies = {
+    s3_writer = aws_iam_policy.writer[0].arn
+  }
+  tags = merge(var.tags, var.iam_user_tags)
+}
+
+resource "aws_secretsmanager_secret" "writer" {
+  count                   = var.enable_iam_writer ? 1 : 0
+  name                    = local.secret_name
+  recovery_window_in_days = var.secret_recovery_window_in_days
+  kms_key_id              = var.secret_kms_key_id
+  tags                    = var.tags
+}
+
+resource "aws_secretsmanager_secret_version" "writer" {
+  count     = var.enable_iam_writer ? 1 : 0
+  secret_id = aws_secretsmanager_secret.writer[0].id
+  secret_string = jsonencode({
+    s3_access_key = module.writer[0].access_key_id
+    s3_secret_key = module.writer[0].access_key_secret
+  })
 }

--- a/infrastructure/s3/main.tf
+++ b/infrastructure/s3/main.tf
@@ -48,16 +48,13 @@ resource "aws_iam_policy" "writer" {
 module "writer" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-user"
   version = "~> 6.6"
-  count   = var.enable_iam_writer ? 1 : 0
 
-  create               = true
+  create               = var.enable_iam_writer
   name                 = local.iam_user_name
   create_login_profile = false
   create_access_key    = true
-  policies = {
-    s3_writer = aws_iam_policy.writer[0].arn
-  }
-  tags = merge(var.tags, var.iam_user_tags)
+  policies             = var.enable_iam_writer ? { s3_writer = aws_iam_policy.writer[0].arn } : {}
+  tags                 = merge(var.tags, var.iam_user_tags)
 }
 
 resource "aws_secretsmanager_secret" "writer" {
@@ -72,7 +69,7 @@ resource "aws_secretsmanager_secret_version" "writer" {
   count     = var.enable_iam_writer ? 1 : 0
   secret_id = aws_secretsmanager_secret.writer[0].id
   secret_string = jsonencode({
-    s3_access_key = module.writer[0].access_key_id
-    s3_secret_key = module.writer[0].access_key_secret
+    s3_access_key = module.writer.access_key_id
+    s3_secret_key = module.writer.access_key_secret
   })
 }

--- a/infrastructure/s3/output.tf
+++ b/infrastructure/s3/output.tf
@@ -15,17 +15,17 @@ output "s3_bucket_domain_name" {
 
 output "iam_writer_user_name" {
   description = "The IAM writer user name, when enabled."
-  value       = try(module.writer[0].name, null)
+  value       = module.writer.name
 }
 
 output "iam_writer_user_arn" {
   description = "The IAM writer user ARN, when enabled."
-  value       = try(module.writer[0].arn, null)
+  value       = module.writer.arn
 }
 
 output "iam_writer_access_key_id" {
   description = "The IAM writer access key ID, when enabled."
-  value       = try(module.writer[0].access_key_id, null)
+  value       = module.writer.access_key_id
   sensitive   = true
 }
 

--- a/infrastructure/s3/output.tf
+++ b/infrastructure/s3/output.tf
@@ -1,9 +1,40 @@
 output "s3_bucket_arn" {
-  value = module.s3_bucket.s3_bucket_arn
-
+  description = "The ARN of the S3 bucket."
+  value       = module.s3_bucket.s3_bucket_arn
 }
 
 output "s3_bucket_id" {
-  value = module.s3_bucket.s3_bucket_bucket_domain_name
+  description = "The name/id of the S3 bucket."
+  value       = module.s3_bucket.s3_bucket_id
+}
 
+output "s3_bucket_domain_name" {
+  description = "The bucket domain name."
+  value       = module.s3_bucket.s3_bucket_bucket_domain_name
+}
+
+output "iam_writer_user_name" {
+  description = "The IAM writer user name, when enabled."
+  value       = try(module.writer[0].name, null)
+}
+
+output "iam_writer_user_arn" {
+  description = "The IAM writer user ARN, when enabled."
+  value       = try(module.writer[0].arn, null)
+}
+
+output "iam_writer_access_key_id" {
+  description = "The IAM writer access key ID, when enabled."
+  value       = try(module.writer[0].access_key_id, null)
+  sensitive   = true
+}
+
+output "iam_writer_secret_arn" {
+  description = "The Secrets Manager secret ARN containing the IAM writer credentials, when enabled."
+  value       = try(aws_secretsmanager_secret.writer[0].arn, null)
+}
+
+output "iam_writer_secret_name" {
+  description = "The Secrets Manager secret name containing the IAM writer credentials, when enabled."
+  value       = try(aws_secretsmanager_secret.writer[0].name, null)
 }

--- a/infrastructure/s3/variables.tf
+++ b/infrastructure/s3/variables.tf
@@ -51,3 +51,69 @@ variable "force_destroy" {
   type        = bool
   default     = true
 }
+
+variable "block_public_acls" {
+  description = "Whether Amazon S3 should block public ACLs for this bucket."
+  type        = bool
+  default     = null
+}
+
+variable "block_public_policy" {
+  description = "Whether Amazon S3 should block public bucket policies for this bucket."
+  type        = bool
+  default     = null
+}
+
+variable "ignore_public_acls" {
+  description = "Whether Amazon S3 should ignore public ACLs for this bucket."
+  type        = bool
+  default     = null
+}
+
+variable "restrict_public_buckets" {
+  description = "Whether Amazon S3 should restrict public bucket policies for this bucket."
+  type        = bool
+  default     = null
+}
+
+variable "enable_iam_writer" {
+  description = "Create a dedicated IAM user with object R/W permissions on this bucket; store generated access keys in Secrets Manager."
+  type        = bool
+  default     = false
+}
+
+variable "iam_user_name_override" {
+  description = "Override derived IAM user name. IAM user names are unique account-wide."
+  type        = string
+  default     = ""
+}
+
+variable "iam_policy_name_override" {
+  description = "Override derived IAM policy name. Renaming an existing policy forces replace."
+  type        = string
+  default     = ""
+}
+
+variable "secret_name_override" {
+  description = "Override derived Secrets Manager secret name."
+  type        = string
+  default     = ""
+}
+
+variable "iam_user_tags" {
+  description = "Tags merged on top of var.tags for the IAM user only."
+  type        = map(string)
+  default     = {}
+}
+
+variable "secret_recovery_window_in_days" {
+  description = "Recovery window for the Secrets Manager secret. Set to 0 in dev/test to allow immediate destroy+recreate."
+  type        = number
+  default     = 7
+}
+
+variable "secret_kms_key_id" {
+  description = "Optional KMS CMK ARN/ID for the Secrets Manager secret. Defaults to AWS-managed aws/secretsmanager."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Summary
- Absorb the bucket + IAM user + Secrets Manager pattern from consumer-side `fineract-s3.tf` into the s3 module so customers no longer copy that file.
- New opt-in flag `enable_iam_writer` (default `false`). Names derive from `bucket_name`; three overrides (`iam_user_name_override`, `iam_policy_name_override`, `secret_name_override`) preserve resource identity during migration.
- Expose the four S3 public-access-block flags as pass-through vars (default `null` keeps upstream defaults; no diff for current callers).
- Pin `terraform-aws-modules/s3-bucket/aws ~> 5.0` → `~> 5.13`. Add `terraform-aws-modules/iam/aws ~> 6.6`.

## ⚠️ BREAKING
`output.s3_bucket_id` was wired to `s3_bucket_bucket_domain_name` (a bug). It now returns the actual bucket id. A new output `s3_bucket_domain_name` preserves the previous (buggy) value for any caller that relied on it.

## Test plan
- [x] `terraform fmt -check -recursive`
- [x] `terraform validate` in `infrastructure/s3`
- [x] `terraform validate` in `infrastructure/s3/example`
- [x] `tflint --chdir=infrastructure/s3 --minimum-failure-severity=error`
- [x] CI matrix `Validate: infrastructure/s3` passes
- [x] CI `docs` job regenerates README to surface the new vars + outputs

## Follow-up (separate PR)
Migrate `fiter-infrastructure-v2/.tf_files/infrastructure/fineract-s3.tf` to this module via a single module call + `moved {}` blocks to preserve state addresses. Override values:
```hcl
iam_user_name_override   = "fineract-s3-user-${var.environment}"
iam_policy_name_override = "fineract-s3-user-${var.environment}-policy"
secret_name_override     = "kubernetes/${local.cluster_name}/fineract-s3-user-content"
```