### PR TITLE
feat(gh-actions-iam-role): grant tf-deploy role full ecr-public access

### DIFF
--- a/infrastructure/gh-actions-iam-role/main.tf
+++ b/infrastructure/gh-actions-iam-role/main.tf
@@ -79,7 +79,7 @@ resource "aws_iam_policy" "terraform_policy" {
           "kms:*",
           "dynamodb:*",
           "apprunner:*",
-          "ecr-public:GetAuthorizationToken",
+          "ecr-public:*",
           "eks:*",
           "kms:*",
           "sts:GetServiceBearerToken",


### PR DESCRIPTION
## What

Replace `ecr-public:GetAuthorizationToken` with `ecr-public:*` (on `Resource "*"`) in the Terraform deploy role policy (`aws_iam_policy.terraform_policy`, `AllowSpecifics` statement) in `infrastructure/gh-actions-iam-role/main.tf`. `sts:GetServiceBearerToken` is retained.

## Why

The tf-deploy role created by this module is consumed by `fiter-infrastructure-v2` (`fiter/dev/account_init`, pinned `?ref=v0.2.0`). That repo now manages **public ECR chart repositories** in Terraform (`aws_ecrpublic_repository`). CI `terraform plan` fails because the role lacks ECR Public repository perms:

```
AccessDeniedException: not authorized to perform: ecr-public:DescribeRepositories
on arn:aws:ecr-public::<acct>:repository/charts/fiter-tigerbeetle
```

The role is a broad Terraform-admin role using service-wide wildcards on `Resource "*"` (`ecr:*`, `iam:*`, `s3:*`, `ec2:*`, …). Granting `ecr-public:*` matches that existing style and is a superset of the required read/write actions (DescribeRepositories, Get*CatalogData, Create/DeleteRepository, Put*CatalogData, Tag/Untag/ListTagsForResource).

## Validation

- `terraform fmt` — clean
- `terraform init -backend=false` — successful
- `terraform validate` — successful

## Follow-up

After merge, **tag a new module version (recommended `v0.5.0`)**, then bump the consumer ref in `fiter-infrastructure-v2` from `v0.2.0` to the new tag and re-run plan.

> ⚠️ Bumping the consumer `v0.2.0 → v0.5.0` pulls in all intermediate module changes (v0.3.0, v0.4.0). Review the full `v0.2.0..v0.5.0` diff across modules before the consumer bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)