### PR TITLE
refactor(rds-credential-manager)!: move Secrets Manager VPC endpoint to vpc module

### DIFF
--- a/infrastructure/rds-credential-manager/README.md
+++ b/infrastructure/rds-credential-manager/README.md
@@ -32,6 +32,10 @@ module "vpc" {
   customer    = "example-customer"
   vpc_cidr    = "10.0.0.0/16"
   common_tags = { Name = "example-customer-dev", Environment = "dev" }
+
+  # Secrets Manager interface endpoint — lets the in-VPC credential-manager Lambda reach Secrets Manager
+  enable_network_endpoints = true
+  vpc_interface_endpoints  = ["secretsmanager"]
 }
 
 module "rds" {
@@ -69,8 +73,6 @@ module "credential_manager" {
   engine = "postgres"
 
   # Networking — Lambda runs inside the VPC to reach the RDS instance
-  vpc_id             = module.vpc.vpc_id
-  vpc_cidr           = module.vpc.vpc_cidr_block
   subnets            = module.vpc.private_subnets
   security_group_ids = [module.rds.rds_security_group]
 
@@ -104,6 +106,10 @@ module "credential_manager" {
     Environment = "dev"
     ManagedBy   = "terraform"
   }
+
+  # Ensure the Secrets Manager endpoint (created in the vpc module) exists before the
+  # Lambda is invoked, otherwise the in-VPC invocation can't reach Secrets Manager.
+  depends_on = [module.vpc]
 }
 ```
 
@@ -112,7 +118,6 @@ module "credential_manager" {
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_credential_manager"></a> [credential\_manager](#module\_credential\_manager) | terraform-aws-modules/lambda/aws | ~> 8.0 |
-| <a name="module_endpoints"></a> [endpoints](#module\_endpoints) | terraform-aws-modules/vpc/aws//modules/vpc-endpoints | ~> 6.0 |
 | <a name="module_pymysql_layer"></a> [pymysql\_layer](#module\_pymysql\_layer) | terraform-aws-modules/lambda/aws | ~> 8.0 |
 
 ## Resources
@@ -136,7 +141,6 @@ module "credential_manager" {
 | <a name="input_db_service_users"></a> [db\_service\_users](#input\_db\_service\_users) | service user to create for application | <pre>list(object({<br/>    user        = string<br/>    access_type = string<br/>    db_owner    = string<br/>    databases   = list(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | Docker image to use for the Lambda function | `string` | `null` | no |
 | <a name="input_enable_credential_manager"></a> [enable\_credential\_manager](#input\_enable\_credential\_manager) | Enable Credential Manager | `bool` | `true` | no |
-| <a name="input_enable_secretmanager_vpc_endpoint"></a> [enable\_secretmanager\_vpc\_endpoint](#input\_enable\_secretmanager\_vpc\_endpoint) | Enable VPC Endpoint for Secrets Manager | `bool` | `false` | no |
 | <a name="input_engine"></a> [engine](#input\_engine) | The database engine to use | `string` | `"postgres"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name | `string` | n/a | yes |
 | <a name="input_function_code_path"></a> [function\_code\_path](#input\_function\_code\_path) | Path to the Lambda function code | `string` | `"lambdas"` | no |
@@ -149,8 +153,6 @@ module "credential_manager" {
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | List of subnets to use for the RDS cluster | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to the resources | `map(any)` | `{}` | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | Timeout for the Lambda function | `number` | `120` | no |
-| <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR block of the VPC | `string` | n/a | yes |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID where the RDS instance will be deployed | `string` | n/a | yes |
 
 ## Outputs
 

--- a/infrastructure/rds-credential-manager/example/main.tf
+++ b/infrastructure/rds-credential-manager/example/main.tf
@@ -9,6 +9,10 @@ module "vpc" {
   customer    = "example-customer"
   vpc_cidr    = "10.0.0.0/16"
   common_tags = { Name = "example-customer-dev", Environment = "dev" }
+
+  # Secrets Manager interface endpoint — lets the in-VPC credential-manager Lambda reach Secrets Manager
+  enable_network_endpoints = true
+  vpc_interface_endpoints  = ["secretsmanager"]
 }
 
 module "rds" {
@@ -46,8 +50,6 @@ module "credential_manager" {
   engine = "postgres"
 
   # Networking — Lambda runs inside the VPC to reach the RDS instance
-  vpc_id             = module.vpc.vpc_id
-  vpc_cidr           = module.vpc.vpc_cidr_block
   subnets            = module.vpc.private_subnets
   security_group_ids = [module.rds.rds_security_group]
 
@@ -81,4 +83,8 @@ module "credential_manager" {
     Environment = "dev"
     ManagedBy   = "terraform"
   }
+
+  # Ensure the Secrets Manager endpoint (created in the vpc module) exists before the
+  # Lambda is invoked, otherwise the in-VPC invocation can't reach Secrets Manager.
+  depends_on = [module.vpc]
 }

--- a/infrastructure/rds-credential-manager/lambdas/postgres/Dockerfile
+++ b/infrastructure/rds-credential-manager/lambdas/postgres/Dockerfile
@@ -1,6 +1,6 @@
 FROM amazon/aws-lambda-python:3.9-x86_64
 COPY requirements.txt .
 RUN pip3 install -r requirements.txt
-COPY app.py ./
+COPY index.py ./
 
-CMD ["app.lambda_handler"]
+CMD ["index.lambda_handler"]

--- a/infrastructure/rds-credential-manager/lambdas/postgres/index.py
+++ b/infrastructure/rds-credential-manager/lambdas/postgres/index.py
@@ -1,77 +1,99 @@
 import os
+import sys
 import json
 import logging
 import boto3
 from botocore.exceptions import ClientError
-import psycopg2
-from psycopg2 import sql
-from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+import psycopg
+from psycopg import sql
 
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
 
-def create_secret(client, secret_name, username):
-    try:
-        randomPassword = client.get_random_password(
-            PasswordLength=16,
-            ExcludePunctuation=True
-        )
-        password = randomPassword["RandomPassword"]
-        secret = json.dumps({
-            "username": username,
-            "password": password
-        })
-        client.create_secret(
-            Name=secret_name,
-            SecretString=secret,
-            Tags=[
-                {
-                    'Key': 'OwnedBy',
-                    'Value': 'Terraform'
-                },
-            ],
-        )
-    except ClientError as error:
-        if error.response['Error']['Code'] == 'ResourceExistsException':
-            secret = get_secret(client, secret_name)
-            password = secret["password"]
-        else:
-            raise error
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+def create_secret(client, secret_name, username, db_owner):
+    SECRET_BACKEND = os.environ.get("SECRET_BACKEND", "aws").lower()
+
+    if SECRET_BACKEND == "aws":
+        try:
+            randomPassword = client.get_random_password(
+                PasswordLength=16,
+                ExcludePunctuation=True
+            )
+            password = randomPassword["RandomPassword"]
+        except ClientError as e:
+            logger.error(f"Failed to generate AWS random password: {e}")
+            raise e
+    else:
+        password = os.environ.get("DB_PASSWORD")
+        if not password:
+            logger.error("Missing DB_PASSWORD environment variable in local mode.")
+            raise ValueError("DB_PASSWORD must be set when SECRET_BACKEND=local")
+
+        logger.info(f"[LOCAL MODE] Using provided password from environment for {username}")
+
+    secret = {
+        "username": username,
+        "password": password,
+        "host": os.environ.get("DB_HOST"),
+        "jdbc_url": f"jdbc:postgresql://{os.environ.get('DB_HOST')}:{os.environ.get('DB_PORT')}/{db_owner}"
+    }
+
+    if SECRET_BACKEND == "aws":
+        try:
+            client.create_secret(
+                Name=secret_name,
+                SecretString=json.dumps(secret),
+                Tags=[
+                    {
+                        'Key': 'OwnedBy',
+                        'Value': 'Terraform'
+                     }],
+            )
+            logger.info(f"Secret {secret_name} created in AWS Secrets Manager.")
+        except ClientError as error:
+            if error.response['Error']['Code'] == 'ResourceExistsException':
+                existing_secret = get_secret(client, secret_name)
+                password = existing_secret["password"]
+                logger.info(f"Secret {secret_name} already exists. Using existing password.")
+            else:
+                logger.error(f"Error creating secret {secret_name}: {error}")
+                raise error
+    else:
+        logger.info("[LOCAL MODE] Secret not stored in AWS.")
 
     return password
 
 def get_secret(client, secret_name):
-    logger.info(f"attempting to get {secret_name}")
+    logger.info(f"attempting to get secret: {secret_name}")
     try:
-        get_secret_value_response = client.get_secret_value(
-            SecretId=secret_name
-        )
+        get_secret_value_response = client.get_secret_value(SecretId=secret_name)
+        secret = get_secret_value_response['SecretString']
+        return json.loads(secret)
     except ClientError as e:
+        logger.error(f"Error retrieving secret {secret_name}: {e}")
         raise e
-    
-    secret = get_secret_value_response['SecretString']
-    return json.loads(secret)
+
 
 def delete_secret(client, secret_name):
-    logger.info(f"attempting to Delete {secret_name}")
+    logger.info(f"Attempting to delete secret: {secret_name}")
     try:
-        response = client.delete_secret(
-            SecretId=secret_name,
-            ForceDeleteWithoutRecovery=True
-        )
+        client.delete_secret(SecretId=secret_name, ForceDeleteWithoutRecovery=True)
+        logger.info(f"Secret {secret_name} deleted successfully.")
+        return True
     except ClientError as e:
+        logger.error(f"Error deleting secret {secret_name}: {e}")
         raise e
-    return True
 
 def db_connection_manager(db_params, database, query):
-    db_params["database"] = database
+    db_params["dbname"] = database
     try:
-        connection = psycopg2.connect(**db_params)
-        connection.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+        connection = psycopg.connect(**db_params)
+        # connection.isolation_level(IsolationLevel.READ_UNCOMMITTED)
         connection.autocommit = True
         cursor = connection.cursor()
         cursor.execute(query)
-    except (Exception, psycopg2.Error) as error:
+    except (Exception, psycopg.Error) as error:
         logger.error(f"Error connecting to the database: {error}")
     finally:
         if connection:
@@ -82,36 +104,43 @@ def db_connection_manager(db_params, database, query):
 
 def db_manager(event):
     DB_IDENTIFIER = os.environ["DB_IDENTIFIER"]
+    SECRET_PATH = os.environ["SECRET_PATH"]
     USER_NAME = f'{event["USERNAME"]}'
-    SECRET_NAME = f'{DB_IDENTIFIER}-{USER_NAME}-secret'
+    SECRET_NAME = f'{SECRET_PATH}/{USER_NAME}'
     DATABASES = event["DATABASES"]
-    REGION_NAME = os.environ['AWS_REGION']
+    REGION_NAME = os.environ['AWS_REGION'] if os.environ.get("SECRET_BACKEND", "aws").lower() == "aws" else None
     ADMIN_SECRET_NAME = os.environ["ADMIN_SECRET_NAME"]
     DB_HOST = os.environ["DB_HOST"]
+    DB_PORT = os.environ["DB_PORT"]
     ADMIN_DB_NAME = os.environ["ADMIN_DB_NAME"]
     DB_INIT = f'{event["DB_INIT"]}'
     ACCESS_TYPE = f'{event["ACCESS_TYPE"]}'
+    DB_OWNER = f'{event["DB_OWNER"]}'
+    SECRET_BACKEND = os.environ.get("SECRET_BACKEND", "aws").lower()
 
-    session = boto3.session.Session()
-    client = session.client(
-        service_name='secretsmanager',
-        region_name=REGION_NAME
-    )
-
-    db_secret = get_secret(client, ADMIN_SECRET_NAME)
+    if SECRET_BACKEND == "aws":
+        session = boto3.session.Session()
+        client = session.client(service_name='secretsmanager', region_name=REGION_NAME)
+        db_secret = get_secret(client, ADMIN_SECRET_NAME)
+    else:
+        logger.info("Running in local mode skipping AWS Secrets Manager.")
+        client = None
+        db_secret = {
+            "username": os.getenv("USERNAME"),
+            "password": os.getenv("PASSWORD"),
+        }
 
     db_params = {
         "host": DB_HOST,
-        "database": ADMIN_DB_NAME,
+        "dbname": ADMIN_DB_NAME,
         "user": db_secret["username"],
         "password": db_secret["password"],
-        "port": "5432",
-        "sslmode": "require"
+        "port": DB_PORT,
+        "sslmode": "disable" if SECRET_BACKEND == "local" else "require"
     }
 
     try:
-        connection = psycopg2.connect(**db_params)
-        connection.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+        connection = psycopg.connect(**db_params)
         connection.autocommit = True
         cursor = connection.cursor()
 
@@ -135,7 +164,7 @@ def db_manager(event):
                             DO $$
                             BEGIN
                                 REVOKE CREATE ON SCHEMA public FROM PUBLIC;
-                                GRANT USAGE, CREATE ON SCHEMA public TO {database_name}_readwrite;
+                                GRANT ALL ON SCHEMA public TO {database_name}_readwrite;
                                 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO {database_name}_readwrite;
                                 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO {database_name}_readwrite;
                                 GRANT USAGE ON ALL SEQUENCES IN SCHEMA public TO {database_name}_readwrite;
@@ -144,9 +173,11 @@ def db_manager(event):
                                 GRANT pg_write_all_data TO {database_name}_readwrite;
                                 GRANT USAGE ON SCHEMA public TO {database_name}_readonly;
                                 GRANT SELECT ON ALL TABLES IN SCHEMA public TO {database_name}_readonly;
+                                GRANT {database_name}_readwrite TO postgres;
                                 ALTER DEFAULT PRIVILEGES FOR ROLE {database_name}_readwrite IN SCHEMA public GRANT SELECT ON TABLES TO {database_name}_readonly;
                                 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO {database_name}_readonly;
                                 GRANT pg_read_all_data TO {database_name}_readonly;
+                                CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
                             END $$;
                         """
                         db_connection_manager(db_params, database_name, queries)
@@ -158,12 +189,12 @@ def db_manager(event):
                 user_exists = cursor.fetchone()
 
                 if not user_exists:
-                    user_secret = create_secret(client, SECRET_NAME, USER_NAME)
+                    user_secret = create_secret(client, SECRET_NAME, USER_NAME, DB_OWNER)
                     cursor.execute(
-                        sql.SQL("CREATE USER {} WITH PASSWORD %s").format(
-                            sql.Identifier(USER_NAME)
-                        ),
-                        (user_secret,)
+                        sql.SQL("CREATE USER {} WITH PASSWORD {}").format(
+                            sql.Identifier(USER_NAME),
+                            sql.Literal(user_secret)
+                        )
                     )
                     cursor.execute(f"REVOKE ALL PRIVILEGES ON DATABASE postgres FROM {USER_NAME}")
                     for database_name in DATABASES:
@@ -188,8 +219,8 @@ def db_manager(event):
             else:
                 logger.info(f"No Action to take'")
 
-    except (Exception, psycopg2.Error) as error:
-        logger.info(f"Error connecting to the database: {error}")
+    except (Exception, psycopg.Error) as error:
+        logger.error(f"Error connecting to the database: {error}")
 
     finally:
         if connection:

--- a/infrastructure/rds-credential-manager/lambdas/postgres/index.py
+++ b/infrastructure/rds-credential-manager/lambdas/postgres/index.py
@@ -50,14 +50,14 @@ def create_secret(client, secret_name, username, db_owner):
                         'Value': 'Terraform'
                      }],
             )
-            logger.info(f"Secret {secret_name} created in AWS Secrets Manager.")
+            logger.info("Secret created in AWS Secrets Manager.")
         except ClientError as error:
             if error.response['Error']['Code'] == 'ResourceExistsException':
                 existing_secret = get_secret(client, secret_name)
                 password = existing_secret["password"]
-                logger.info(f"Secret {secret_name} already exists. Using existing password.")
+                logger.info("Secret already exists. Using existing password.")
             else:
-                logger.error(f"Error creating secret {secret_name}: {error}")
+                logger.error(f"Error creating secret: {error}")
                 raise error
     else:
         logger.info("[LOCAL MODE] Secret not stored in AWS.")
@@ -65,24 +65,24 @@ def create_secret(client, secret_name, username, db_owner):
     return password
 
 def get_secret(client, secret_name):
-    logger.info(f"attempting to get secret: {secret_name}")
+    logger.info("Attempting to get secret.")
     try:
         get_secret_value_response = client.get_secret_value(SecretId=secret_name)
         secret = get_secret_value_response['SecretString']
         return json.loads(secret)
     except ClientError as e:
-        logger.error(f"Error retrieving secret {secret_name}: {e}")
+        logger.error(f"Error retrieving secret: {e}")
         raise e
 
 
 def delete_secret(client, secret_name):
-    logger.info(f"Attempting to delete secret: {secret_name}")
+    logger.info("Attempting to delete secret.")
     try:
         client.delete_secret(SecretId=secret_name, ForceDeleteWithoutRecovery=True)
-        logger.info(f"Secret {secret_name} deleted successfully.")
+        logger.info("Secret deleted successfully.")
         return True
     except ClientError as e:
-        logger.error(f"Error deleting secret {secret_name}: {e}")
+        logger.error(f"Error deleting secret: {e}")
         raise e
 
 def db_connection_manager(db_params, database, query):

--- a/infrastructure/rds-credential-manager/main.tf
+++ b/infrastructure/rds-credential-manager/main.tf
@@ -107,7 +107,6 @@ resource "aws_lambda_invocation" "postgres_init" {
     "DB_OWNER"    = ""
     "ACCESS_TYPE" = "readonly"
   })
-  depends_on = [module.endpoints]
 }
 
 # Invoke to create users
@@ -126,35 +125,6 @@ resource "aws_lambda_invocation" "db_service" {
   })
 
   depends_on = [
-    module.endpoints,
     aws_lambda_invocation.postgres_init
   ]
-}
-
-module "endpoints" {
-  count   = var.enable_secretmanager_vpc_endpoint ? 1 : 0
-  source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
-  version = "~> 6.0"
-
-  vpc_id                = var.vpc_id
-  create_security_group = true
-
-  security_group_name_prefix = "${var.name}-vpc-endpoints-"
-  security_group_description = "VPC endpoint security group"
-  security_group_rules = {
-    ingress_https = {
-      description = "HTTPS from VPC"
-      cidr_blocks = [var.vpc_cidr]
-    }
-  }
-  subnet_ids = var.subnets
-
-  endpoints = {
-    secretsmanager = {
-      # interface endpoint
-      service             = "secretsmanager"
-      private_dns_enabled = true
-      tags                = { Name = "secretsmanager-vpc-endpoint" }
-    },
-  }
 }

--- a/infrastructure/rds-credential-manager/variable.tf
+++ b/infrastructure/rds-credential-manager/variable.tf
@@ -138,22 +138,6 @@ variable "lambda_source_path" {
   default     = ""
 }
 
-variable "enable_secretmanager_vpc_endpoint" {
-  type        = bool
-  description = "Enable VPC Endpoint for Secrets Manager"
-  default     = false
-}
-
-variable "vpc_id" {
-  type        = string
-  description = "VPC ID where the RDS instance will be deployed"
-}
-
-variable "vpc_cidr" {
-  type        = string
-  description = "CIDR block of the VPC"
-}
-
 variable "database_port" {
   type        = number
   description = "Port number for the database"


### PR DESCRIPTION
## Summary

The **vpc module should own all network components.** `rds-credential-manager` currently creates the Secrets Manager interface endpoint itself (the in-VPC Lambda needs it to reach Secrets Manager). The vpc module already provisions interface endpoints generically (`enable_network_endpoints` + `vpc_interface_endpoints`), so the endpoint moves there.

This PR also bundles a pre-existing modernization of the postgres Lambda.

### Network refactor (`rds-credential-manager`)
- Removed the in-module `module "endpoints"` block and the `depends_on = [module.endpoints]` wiring on both lambda invocations.
- Removed the now-dead variables: `enable_secretmanager_vpc_endpoint`, `vpc_id`, `vpc_cidr` (confirmed used nowhere else; tflint clean).
- Example now wires the endpoint through the vpc module:
  ```hcl
  module "vpc" {
    enable_network_endpoints = true
    vpc_interface_endpoints  = ["secretsmanager"]
  }
  module "credential_manager" {
    subnets    = module.vpc.private_subnets
    depends_on = [module.vpc]  # endpoint must exist before the Lambda is invoked
  }
  ```
- No change needed in the vpc module — it already supports this.

### Postgres Lambda modernization
- Migrate `psycopg2` → `psycopg` (v3); rename handler `app.lambda_handler` → `index.lambda_handler` (Dockerfile updated).
- Add `SECRET_BACKEND` (`aws` | `local`) mode; secret naming via `SECRET_PATH/USERNAME`.
- Add `DB_PORT` / `DB_OWNER` handling, `uuid-ossp` extension, and grant adjustments.

## Ordering note
Passing `subnets = module.vpc.private_subnets` only orders on the subnets, not the endpoint resource. Ordering is re-established consumer-side via `depends_on = [module.vpc]` on the credential_manager call.

## Verification
- `terraform fmt -recursive` — clean
- `terraform validate` — passes on `vpc`, `rds-credential-manager`, and the example
- `tflint --minimum-failure-severity=error` — exits 0

## Breaking change — caller migration
`rds-credential-manager` no longer accepts `vpc_id`, `vpc_cidr`, or `enable_secretmanager_vpc_endpoint`. Consumers must:
1. Set `enable_network_endpoints = true` + `vpc_interface_endpoints = ["secretsmanager"]` on the vpc module.
2. Drop the three removed args from the credential_manager call.
3. Add `depends_on = [module.vpc]` to the credential_manager call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)